### PR TITLE
feat: allow a 3rd metric in scatter to set symbol size

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -276,7 +276,7 @@ export class Chart<T extends ChartType> {
         aggregation: "none",
       })
     );
-    if (chart.canAddMetric()) {
+    if (this.metrics.length < 2) {
       chart.addMetric({ ...chart.getMetrics()[0], id: 1 }); // re-add same metric
     }
     return chart;
@@ -402,7 +402,7 @@ export class Chart<T extends ChartType> {
     } else if (["bar", "line"].includes(this.chartType)) {
       return this.dimensions.length < 2;
     } else if (this.chartType === "scatter") {
-      return this.metrics.length < 2;
+      return this.metrics.length < 3;
     } else {
       return false;
     }

--- a/src/determine/series.ts
+++ b/src/determine/series.ts
@@ -54,7 +54,15 @@ export function series<T extends ChartType>(
       item.radius = ["40%", "70%"];
     } else if (chart.getChartType() === "scatter") {
       const metrics = chart.getMetrics();
-      item.symbolSize = 15;
+      if (metrics.length === 2) {
+        item.symbolSize = 15;
+      } else if (metrics.length === 3) {
+        item.symbolSize = (value: Array<number | string>) => {
+          const number = Number(value[metrics[2].index]);
+          const exponent = Math.floor(Math.log10(number)) + 1;
+          return number / 10 ** (exponent - 2);
+        };
+      }
       item.encode = {
         x: dataset.dimensions[metrics[0].index],
         y: dataset.dimensions[metrics[1].index],

--- a/src/types/echarts/series.ts
+++ b/src/types/echarts/series.ts
@@ -26,7 +26,7 @@ export default interface Series extends IStylable {
   radius?: string[];
   areaStyle?: object;
   itemStyle?: object;
-  symbolSize?: number;
+  symbolSize?: number | ((value: Array<number | string>) => number);
   calendarIndex?: number;
   coordinateSystem?: string;
   datasetIndex?: number;

--- a/test/spec/convert.test.ts
+++ b/test/spec/convert.test.ts
@@ -35,7 +35,7 @@ describe("given an initial bar chart", () => {
     expect(newChart.getChartType()).toEqual("scatter");
     expect(newChart.getBreakdownDimension()).toBeUndefined();
     expect(newChart.canAddDimension()).toBe(true);
-    expect(newChart.canAddMetric()).toBe(false);
+    expect(newChart.canAddMetric()).toBe(true); // user can add a metric to control symbol size
     expect(newChart.getStyleShowTitle()).toBe(false);
   });
   it("can then be converted to a heatmap chart", () => {


### PR DESCRIPTION
metric 1 = x axis
metric 2 = y axis
metric 3 = symbol size (z axis)

This was the easiest way to add this feature in the short term. Can/will revisit to make it more intuitive for the user.