### PR TITLE
fix: normalize boolean values to string for dataframe

### DIFF
--- a/src/dataframe.ts
+++ b/src/dataframe.ts
@@ -23,7 +23,11 @@ export class DataFrame {
           }
         });
       }
-      this.data.push(Object.values(row));
+      // normalize boolean values to string
+      const values = Object.values(row).map((v) =>
+        typeof v === "boolean" ? String(v) : v
+      );
+      this.data.push(values);
     });
     this.shape = {
       height: this.data.length,

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -1,3 +1,5 @@
 import { Option } from "./utility";
 
-export type RowOriented = Array<{ [key: string]: Option<number | string> }>;
+export type RowOriented = Array<{
+  [key: string]: Option<number | string | boolean>;
+}>;


### PR DESCRIPTION
Having boolean values was messing up the dataframe pivot because internally that method was assigning the group by value as a key in a `Map` object. Not sure exactly why it didn't like bools as map keys but casting bools to string did the trick.